### PR TITLE
Improve API base URL resolution

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000';
+function resolveApiBase() {
+  const envBase = import.meta.env.VITE_API_BASE_URL?.trim();
+  if (envBase) {
+    return envBase.replace(/\/+$/, '');
+  }
+
+  if (typeof window !== 'undefined') {
+    const { origin, hostname } = window.location;
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      return 'http://localhost:5000';
+    }
+    return origin.replace(/\/+$/, '');
+  }
+
+  return 'http://localhost:5000';
+}
+
+const API_BASE = resolveApiBase();
 
 const emptyTemplateForm = {
   name: '',


### PR DESCRIPTION
## Summary
- add a helper that resolves the API base URL from environment configuration or the current origin with sensible fallbacks

## Testing
- npm install *(fails: 403 Forbidden retrieving @vitejs/plugin-react from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d9deca34fc832980b1bae9889df6e2