### PR TITLE
Add dual-part label template support

### DIFF
--- a/backend/labelgen/pdf.py
+++ b/backend/labelgen/pdf.py
@@ -23,10 +23,11 @@ class TemplateConfig:
     accent_color: str
     text_align: str
     include_description: bool
+    parts_per_label: int
 
 
 @dataclass(slots=True)
-class LabelData:
+class PartDetails:
     manufacturer: str
     part_number: str
     stock_quantity: int
@@ -34,6 +35,12 @@ class LabelData:
     bin_location: str | None
     image_url: str | None
     notes: str | None
+
+
+@dataclass(slots=True)
+class LabelData:
+    left: PartDetails
+    right: PartDetails | None
     template: TemplateConfig
 
 
@@ -85,6 +92,146 @@ def _wrap_text(value: str, font_name: str, font_size: int, max_width: float) -> 
     return lines
 
 
+def _render_part(
+    canv: canvas.Canvas,
+    part: PartDetails,
+    template: TemplateConfig,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    image_cache: ImageCache,
+    accent: colors.Color,
+    is_split: bool,
+    use_placeholder: bool,
+) -> None:
+    part_padding = 0.12 * inch if is_split else 0.16 * inch
+    inner_x = x + part_padding
+    inner_y = y + part_padding
+    inner_width = max(width - 2 * part_padding, 0)
+    inner_height = max(height - 2 * part_padding, 0)
+
+    text_area_x = inner_x
+    text_area_width = inner_width
+    text_area_y_top = inner_y + inner_height
+
+    effective_position = template.image_position.lower() if template.image_position else "left"
+    if effective_position not in {"left", "top"}:
+        effective_position = "none"
+    if is_split and effective_position == "left":
+        effective_position = "top"
+
+    image = None
+    if part.image_url and effective_position in {"left", "top"}:
+        image = image_cache.get(part.image_url)
+
+    if image is not None and effective_position == "left" and inner_width > 0 and inner_height > 0:
+        image_width = inner_width * 0.38
+        image_height = inner_height
+        aspect = image.width / image.height if image.height else 1
+        target_height = image_width / aspect
+        if target_height > image_height:
+            target_height = image_height
+            image_width = target_height * aspect
+        canv.drawImage(
+            ImageReader(image),
+            inner_x,
+            inner_y + (inner_height - target_height) / 2,
+            width=image_width,
+            height=target_height,
+            preserveAspectRatio=True,
+            mask="auto",
+        )
+        text_area_x = inner_x + image_width + part_padding / 2
+        text_area_width = max(inner_width - image_width - part_padding / 2, 0)
+    elif image is not None and effective_position == "top" and inner_width > 0 and inner_height > 0:
+        image_height = inner_height * (0.45 if is_split else 0.55)
+        image_width = inner_width
+        aspect = image.width / image.height if image.height else 1
+        target_width = image_height * aspect
+        if target_width > image_width:
+            target_width = image_width
+            image_height = target_width / aspect
+        canv.drawImage(
+            ImageReader(image),
+            inner_x + (inner_width - target_width) / 2,
+            inner_y + inner_height - image_height,
+            width=target_width,
+            height=image_height,
+            preserveAspectRatio=True,
+            mask="auto",
+        )
+        text_area_y_top = inner_y + inner_height - image_height - part_padding / 2
+    elif use_placeholder and inner_width > 0 and inner_height > 0:
+        placeholder_height = min(0.65 * inch, inner_height * 0.45)
+        canv.setFillColor(colors.Color(0.92, 0.92, 0.92))
+        canv.rect(
+            inner_x,
+            inner_y + inner_height - placeholder_height,
+            inner_width,
+            placeholder_height,
+            fill=1,
+            stroke=0,
+        )
+        canv.setFillColor(colors.black)
+
+    align_center = template.text_align == "center" and text_area_width > 0
+    heading_size = 12 if is_split else 14
+    subheading_size = 10 if is_split else 12
+    body_size = 9 if is_split else 10
+    description_size = 8 if is_split else 9
+    qty_size = 10 if is_split else 11
+    note_size = 7 if is_split else 8
+
+    text_y = text_area_y_top - (6 if is_split else 4)
+    manufacturer = (part.manufacturer or "Unknown Manufacturer").strip() or "Unknown Manufacturer"
+    canv.setFillColor(accent)
+    canv.setFont("Helvetica-Bold", heading_size)
+    if align_center:
+        canv.drawCentredString(text_area_x + text_area_width / 2, text_y, manufacturer.upper())
+    else:
+        canv.drawString(text_area_x, text_y, manufacturer.upper())
+    text_y -= heading_size + (6 if is_split else 8)
+
+    canv.setFillColor(colors.black)
+    canv.setFont("Helvetica-Bold", subheading_size)
+    part_number = (part.part_number or "").strip() or "—"
+    part_line = f"Part #: {part_number}"
+    if align_center:
+        canv.drawCentredString(text_area_x + text_area_width / 2, text_y, part_line)
+    else:
+        canv.drawString(text_area_x, text_y, part_line)
+    text_y -= subheading_size + (5 if is_split else 6)
+
+    if part.bin_location:
+        canv.setFont("Helvetica", body_size)
+        location_line = f"Bin: {part.bin_location.strip()}"
+        if align_center:
+            canv.drawCentredString(text_area_x + text_area_width / 2, text_y, location_line)
+        else:
+            canv.drawString(text_area_x, text_y, location_line)
+        text_y -= body_size + (5 if is_split else 6)
+
+    if template.include_description and part.description:
+        canv.setFont("Helvetica", description_size)
+        max_width = text_area_width if not align_center else text_area_width * 0.9
+        max_width = max(max_width, 1)
+        for line in _wrap_text(part.description.strip(), "Helvetica", description_size, max_width):
+            if align_center:
+                canv.drawCentredString(text_area_x + text_area_width / 2, text_y, line)
+            else:
+                canv.drawString(text_area_x, text_y, line)
+            text_y -= description_size + (4 if is_split else 4)
+
+    canv.setFont("Helvetica-Bold", qty_size)
+    qty_line = f"On Hand: {part.stock_quantity}"
+    canv.drawString(text_area_x, y + part_padding, qty_line)
+
+    if part.notes:
+        canv.setFont("Helvetica-Oblique", note_size)
+        canv.drawRightString(x + width - part_padding, y + part_padding, part.notes.strip())
+
+
 def draw_label(
     canv: canvas.Canvas,
     label: LabelData,
@@ -106,103 +253,57 @@ def draw_label(
 
     template = label.template
     accent = _hex_to_color(template.accent_color)
+    is_split = template.parts_per_label == 2 and label.right is not None
 
-    text_area_x = inner_x
-    text_area_width = inner_width
-    text_area_y_top = inner_y + inner_height
-
-    if label.image_url and template.image_position in {"left", "top"}:
-        image = image_cache.get(label.image_url)
-    else:
-        image = None
-
-    if image is not None and template.image_position == "left":
-        image_width = inner_width * 0.42
-        image_height = inner_height
-        aspect = image.width / image.height
-        target_height = image_width / aspect
-        if target_height > image_height:
-            target_height = image_height
-            image_width = target_height * aspect
-        canv.drawImage(
-            ImageReader(image),
+    if is_split:
+        column_gap = padding / 2
+        column_width = (inner_width - column_gap) / 2 if inner_width > 0 else 0
+        _render_part(
+            canv,
+            label.left,
+            template,
             inner_x,
-            inner_y + (inner_height - target_height) / 2,
-            width=image_width,
-            height=target_height,
-            preserveAspectRatio=True,
-            mask="auto",
+            inner_y,
+            column_width,
+            inner_height,
+            image_cache,
+            accent,
+            is_split=True,
+            use_placeholder=False,
         )
-        text_area_x = inner_x + image_width + padding / 2
-        text_area_width = inner_width - image_width - padding / 2
-    elif image is not None and template.image_position == "top":
-        image_height = inner_height * 0.55
-        image_width = inner_width
-        aspect = image.width / image.height
-        target_width = image_height * aspect
-        if target_width > image_width:
-            target_width = image_width
-            image_height = target_width / aspect
-        canv.drawImage(
-            ImageReader(image),
-            inner_x + (inner_width - target_width) / 2,
-            inner_y + inner_height - image_height,
-            width=target_width,
-            height=image_height,
-            preserveAspectRatio=True,
-            mask="auto",
+        if label.right:
+            right_x = inner_x + column_width + column_gap
+            _render_part(
+                canv,
+                label.right,
+                template,
+                right_x,
+                inner_y,
+                column_width,
+                inner_height,
+                image_cache,
+                accent,
+                is_split=True,
+                use_placeholder=False,
+            )
+        divider_x = inner_x + column_width + column_gap / 2
+        canv.setStrokeColor(colors.Color(0.82, 0.82, 0.82))
+        canv.setLineWidth(0.8)
+        canv.line(divider_x, inner_y, divider_x, inner_y + inner_height)
+    else:
+        _render_part(
+            canv,
+            label.left,
+            template,
+            inner_x,
+            inner_y,
+            inner_width,
+            inner_height,
+            image_cache,
+            accent,
+            is_split=False,
+            use_placeholder=True,
         )
-        text_area_y_top = inner_y + inner_height - image_height - padding / 2
-    else:
-        canv.setFillColor(colors.Color(0.92, 0.92, 0.92))
-        canv.rect(inner_x, inner_y + inner_height - 0.8 * inch, inner_width, 0.8 * inch, fill=1, stroke=0)
-        canv.setFillColor(colors.black)
-
-    text_y = text_area_y_top - 4
-    canv.setFillColor(accent)
-    canv.setFont("Helvetica-Bold", 14)
-    manufacturer = label.manufacturer.strip() or "Unknown Manufacturer"
-    if template.text_align == "center":
-        canv.drawCentredString(text_area_x + text_area_width / 2, text_y, manufacturer.upper())
-    else:
-        canv.drawString(text_area_x, text_y, manufacturer.upper())
-    text_y -= 18
-
-    canv.setFillColor(colors.black)
-    canv.setFont("Helvetica-Bold", 12)
-    part_line = f"Part #: {label.part_number.strip()}"
-    if template.text_align == "center":
-        canv.drawCentredString(text_area_x + text_area_width / 2, text_y, part_line)
-    else:
-        canv.drawString(text_area_x, text_y, part_line)
-    text_y -= 16
-
-    canv.setFont("Helvetica", 10)
-    if label.bin_location:
-        location_line = f"Bin: {label.bin_location.strip()}"
-        if template.text_align == "center":
-            canv.drawCentredString(text_area_x + text_area_width / 2, text_y, location_line)
-        else:
-            canv.drawString(text_area_x, text_y, location_line)
-        text_y -= 14
-
-    canv.setFont("Helvetica", 9)
-    if template.include_description and label.description:
-        max_width = text_area_width if template.text_align != "center" else text_area_width * 0.9
-        for line in _wrap_text(label.description.strip(), "Helvetica", 9, max_width):
-            if template.text_align == "center":
-                canv.drawCentredString(text_area_x + text_area_width / 2, text_y, line)
-            else:
-                canv.drawString(text_area_x, text_y, line)
-            text_y -= 12
-
-    canv.setFont("Helvetica-Bold", 11)
-    qty_line = f"On Hand: {label.stock_quantity}"
-    canv.drawString(text_area_x, y + padding, qty_line)
-
-    if label.notes:
-        canv.setFont("Helvetica-Oblique", 8)
-        canv.drawRightString(x + width - padding, y + padding, label.notes.strip())
 
 
 def build_pdf(labels: Iterable[tuple[LabelData, int]]) -> bytes:

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -126,6 +126,29 @@ label.full {
   grid-column: 1 / -1;
 }
 
+.form-hint {
+  grid-column: 1 / -1;
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.9rem;
+  color: #516079;
+}
+
+.form-divider {
+  grid-column: 1 / -1;
+  margin: 0.5rem 0 0.35rem;
+  padding-top: 0.35rem;
+  border-top: 1px dashed #d0d7e3;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.form-subtext {
+  grid-column: 1 / -1;
+  margin: -0.25rem 0 0.75rem;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
 .checkbox {
   flex-direction: row;
   align-items: center;
@@ -186,6 +209,29 @@ label.full {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.muted {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  font-weight: 600;
+  text-transform: capitalize;
+  font-size: 0.85rem;
 }
 
 .table-row .actions {


### PR DESCRIPTION
## Summary
- add a `parts_per_label` flag and right-side part fields to templates/labels, including validation, serialization, and PDF pairing logic
- extend the React UI to configure dual templates and enter right-side part data while updating list views for clarity
- style new form sections, layout pills, and stacked table content for the two-part label workflow

## Testing
- python -m compileall backend/labelgen
- npm install *(fails with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e123ed948329b707ae5613470691