### PR TITLE
Add visual template playground for customizable layouts

### DIFF
--- a/backend/labelgen/layouts.py
+++ b/backend/labelgen/layouts.py
@@ -1,0 +1,140 @@
+"""Helpers for working with visual label layout configurations."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any
+
+
+FIELD_LIBRARY: dict[str, dict[str, Any]] = {
+    "manufacturer": {"label": "Manufacturer", "sample": "Acme Industries"},
+    "part_number": {"label": "Part number", "sample": "ACM-42-9000"},
+    "description": {"label": "Description", "sample": "Heavy duty fastener"},
+    "stock_quantity": {"label": "Quantity", "sample": "Qty: 128"},
+    "bin_location": {"label": "Bin", "sample": "Bin: A3-14"},
+    "image_url": {"label": "Image", "sample": "Product image"},
+    "notes": {"label": "Notes", "sample": "Handle with care"},
+    "manufacturer_right": {
+        "label": "Manufacturer (right)",
+        "sample": "Globex Corp",
+        "requires_dual": True,
+    },
+    "part_number_right": {
+        "label": "Part number (right)",
+        "sample": "GBX-77-100",
+        "requires_dual": True,
+    },
+    "description_right": {
+        "label": "Description (right)",
+        "sample": "Right side description",
+        "requires_dual": True,
+    },
+    "stock_quantity_right": {
+        "label": "Quantity (right)",
+        "sample": "Qty: 64",
+        "requires_dual": True,
+    },
+    "bin_location_right": {
+        "label": "Bin (right)",
+        "sample": "Bin: B2-07",
+        "requires_dual": True,
+    },
+    "notes_right": {
+        "label": "Notes (right)",
+        "sample": "Secondary notes",
+        "requires_dual": True,
+    },
+}
+
+_DEFAULT_SINGLE_BLOCKS = [
+    {"key": "manufacturer", "width": "half"},
+    {"key": "part_number", "width": "half"},
+    {"key": "description", "width": "full"},
+    {"key": "stock_quantity", "width": "half"},
+    {"key": "bin_location", "width": "half"},
+    {"key": "notes", "width": "full"},
+]
+
+_DEFAULT_DUAL_BLOCKS = [
+    {"key": "manufacturer", "width": "half"},
+    {"key": "part_number", "width": "half"},
+    {"key": "manufacturer_right", "width": "half"},
+    {"key": "part_number_right", "width": "half"},
+    {"key": "description", "width": "full"},
+    {"key": "description_right", "width": "full"},
+    {"key": "stock_quantity", "width": "half"},
+    {"key": "bin_location", "width": "half"},
+    {"key": "stock_quantity_right", "width": "half"},
+    {"key": "bin_location_right", "width": "half"},
+    {"key": "notes", "width": "full"},
+    {"key": "notes_right", "width": "full"},
+]
+
+
+def default_layout_config(
+    parts_per_label: int = 1,
+    include_description: bool = True,
+) -> dict[str, Any]:
+    """Return a default layout configuration for the given template settings."""
+
+    blocks_source = _DEFAULT_DUAL_BLOCKS if parts_per_label == 2 else _DEFAULT_SINGLE_BLOCKS
+    blocks = deepcopy(blocks_source)
+    if not include_description:
+        blocks = [
+            block
+            for block in blocks
+            if block["key"] not in {"description", "description_right"}
+        ]
+    return {"version": 1, "blocks": blocks}
+
+
+def normalize_layout_config(
+    value: Any,
+    parts_per_label: int = 1,
+    include_description: bool = True,
+) -> dict[str, Any]:
+    """Validate a layout payload and return a normalized configuration."""
+
+    parsed: Any
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = None
+    elif isinstance(value, dict):
+        parsed = value
+    else:
+        parsed = None
+
+    blocks: list[dict[str, str]] = []
+    if isinstance(parsed, dict):
+        candidate_blocks = parsed.get("blocks")
+        if isinstance(candidate_blocks, list):
+            for item in candidate_blocks:
+                if not isinstance(item, dict):
+                    continue
+                key = item.get("key")
+                if not isinstance(key, str):
+                    continue
+                field_meta = FIELD_LIBRARY.get(key)
+                if field_meta is None:
+                    continue
+                if field_meta.get("requires_dual") and parts_per_label != 2:
+                    continue
+                if key in {"description", "description_right"} and not include_description:
+                    continue
+                width = item.get("width")
+                normalized_width = "half" if width == "half" else "full"
+                blocks.append({"key": key, "width": normalized_width})
+
+    if not blocks:
+        return default_layout_config(parts_per_label, include_description)
+
+    return {"version": 1, "blocks": blocks}
+
+
+def dumps_layout_config(config: dict[str, Any]) -> str:
+    """Serialize a layout configuration to JSON."""
+
+    return json.dumps(config, separators=(",", ":"))

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -321,3 +321,264 @@ label.full {
     justify-content: flex-start;
   }
 }
+
+.layout-playground {
+  grid-column: 1 / -1;
+}
+
+.template-playground {
+  margin-top: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: var(--color-surface-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.template-playground-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.template-playground-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.playground-hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  max-width: 36ch;
+}
+
+.playground-add {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.playground-add select {
+  font: inherit;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  min-width: 200px;
+}
+
+.playground-add button {
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-text);
+  padding: 0.55rem 0.9rem;
+  border-radius: 10px;
+}
+
+.playground-add button:hover:not(:disabled) {
+  background: var(--color-surface);
+}
+
+.playground-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+@media (min-width: 900px) {
+  .playground-content {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .playground-list,
+  .playground-preview-wrapper {
+    flex: 1;
+  }
+}
+
+.playground-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playground-empty {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.playground-row {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: rgba(15, 26, 46, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playground-row-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.playground-row-subtle {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.playground-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.playground-row-actions label {
+  font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.playground-row-actions select {
+  font: inherit;
+  padding: 0.45rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  min-width: 110px;
+}
+
+.playground-row-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.playground-row-buttons button {
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-text);
+  padding: 0.4rem 0.75rem;
+  border-radius: 10px;
+}
+
+.playground-row-buttons button:hover:not(:disabled) {
+  background: var(--color-surface);
+}
+
+.playground-row-buttons .danger {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: var(--color-error);
+}
+
+.playground-preview-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playground-preview-label {
+  font-weight: 600;
+}
+
+.playground-preview {
+  border: 2px dashed var(--color-border-strong);
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(11, 17, 32, 0.75);
+  display: flex;
+  gap: 1rem;
+  min-height: 220px;
+  transition: border-color 0.2s ease;
+}
+
+.playground-preview.image-top {
+  flex-direction: column;
+}
+
+.playground-preview.image-left {
+  flex-direction: row;
+}
+
+.playground-preview.image-right {
+  flex-direction: row-reverse;
+}
+
+.playground-preview.align-center .playground-block-value {
+  text-align: center;
+}
+
+.playground-preview.align-right .playground-block-value {
+  text-align: right;
+}
+
+.playground-preview-image {
+  flex: 0 0 140px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: rgba(37, 99, 235, 0.25);
+}
+
+.playground-preview.image-top .playground-preview-image {
+  width: 100%;
+  height: 140px;
+  flex: none;
+}
+
+.playground-preview-content {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-content: flex-start;
+}
+
+.playground-block {
+  border-radius: 12px;
+  background: rgba(15, 26, 46, 0.8);
+  border: 1px solid rgba(124, 58, 237, 0.35);
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.playground-block.half {
+  flex: 1 1 calc(50% - 0.75rem);
+}
+
+.playground-block.full {
+  flex: 1 1 100%;
+}
+
+.playground-block-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.playground-block-value {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.playground-footnote {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- add layout configuration storage and normalization helpers to the template API
- expose a visual playground in the frontend for arranging template fields with live preview
- refresh styling to support the new layout builder experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd448c59a08329b32b230781715d85