### PR TITLE
Fix PDF image rendering for uploaded assets

### DIFF
--- a/backend/labelgen/__init__.py
+++ b/backend/labelgen/__init__.py
@@ -455,7 +455,7 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
             )
             chosen.append((label_data, max(1, copies_value)))
 
-        pdf_bytes = pdf.build_pdf(chosen)
+        pdf_bytes = pdf.build_pdf(chosen, uploads_root=app.config.get("UPLOAD_FOLDER"))
         timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
         return send_file(
             io.BytesIO(pdf_bytes),


### PR DESCRIPTION
## Summary
- allow the PDF generator to resolve locally uploaded images in addition to remote URLs
- pass the Flask upload directory into the PDF builder so cached lookups can open files from disk

## Testing
- python -m compileall -f backend/labelgen/pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68dd49d977d48329b02164cb65a75cf9