### PR TITLE
Support layout-driven PDFs and customizable field formats

### DIFF
--- a/backend/labelgen/__init__.py
+++ b/backend/labelgen/__init__.py
@@ -57,6 +57,7 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
             "layout_config": layouts.normalize_layout_config(
                 record["layout_config"], parts_per_label, include_description
             ),
+            "field_formats": layouts.normalize_field_formats(record["field_formats"]),
         }
 
     def _normalize_image_reference(value: str | None) -> str | None:
@@ -116,6 +117,7 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
                     int(record["parts_per_label"] or 1),
                     bool(record["include_description"]),
                 ),
+                "field_formats": layouts.normalize_field_formats(record["field_formats"]),
             },
         }
 
@@ -197,6 +199,9 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
             layout_payload, parts_value, include_description
         )
         data["layout_config"] = layouts.dumps_layout_config(normalized_layout)
+        formats_payload = payload.get("field_formats")
+        normalized_formats = layouts.normalize_field_formats(formats_payload)
+        data["field_formats"] = layouts.dumps_field_formats(normalized_formats)
         template_id = db.upsert_template(data)
         template = db.fetch_template(template_id)
         if template is None:
@@ -235,6 +240,9 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
             layout_payload, parts_value, include_description
         )
         data["layout_config"] = layouts.dumps_layout_config(normalized_layout)
+        formats_payload = payload.get("field_formats")
+        normalized_formats = layouts.normalize_field_formats(formats_payload)
+        data["field_formats"] = layouts.dumps_field_formats(normalized_formats)
         db.upsert_template(data)
         template = db.fetch_template(template_id)
         if template is None:
@@ -423,6 +431,12 @@ def create_app(test_config: dict[str, Any] | None = None) -> Flask:
                 text_align=label["text_align"],
                 include_description=bool(label["include_description"]),
                 parts_per_label=int(label["parts_per_label"] or 1),
+                layout_config=layouts.normalize_layout_config(
+                    label["layout_config"],
+                    int(label["parts_per_label"] or 1),
+                    bool(label["include_description"]),
+                ),
+                field_formats=layouts.normalize_field_formats(label["field_formats"]),
             )
             left_part = pdf.PartDetails(
                 manufacturer=label["manufacturer"],

--- a/backend/labelgen/layouts.py
+++ b/backend/labelgen/layouts.py
@@ -47,6 +47,21 @@ FIELD_LIBRARY: dict[str, dict[str, Any]] = {
     },
 }
 
+FIELD_FORMAT_DEFAULTS: dict[str, str] = {
+    "manufacturer": "{value}",
+    "part_number": "{value_upper}",
+    "description": "{value}",
+    "stock_quantity": "On Hand: {value}",
+    "bin_location": "Bin: {value}",
+    "notes": "{value}",
+    "manufacturer_right": "{value}",
+    "part_number_right": "{value_upper}",
+    "description_right": "{value}",
+    "stock_quantity_right": "On Hand: {value}",
+    "bin_location_right": "Bin: {value}",
+    "notes_right": "{value}",
+}
+
 _DEFAULT_SINGLE_BLOCKS = [
     {"key": "manufacturer", "width": "half"},
     {"key": "part_number", "width": "half"},
@@ -138,3 +153,40 @@ def dumps_layout_config(config: dict[str, Any]) -> str:
     """Serialize a layout configuration to JSON."""
 
     return json.dumps(config, separators=(",", ":"))
+
+
+def normalize_field_formats(value: Any) -> dict[str, str]:
+    """Validate a field format payload and merge with defaults."""
+
+    parsed: Any
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = None
+    elif isinstance(value, dict):
+        parsed = value
+    else:
+        parsed = None
+
+    formats = dict(FIELD_FORMAT_DEFAULTS)
+    if isinstance(parsed, dict):
+        for key, text in parsed.items():
+            if key not in FIELD_LIBRARY:
+                continue
+            if not isinstance(text, str):
+                continue
+            formats[key] = text
+
+    return formats
+
+
+def dumps_field_formats(formats: dict[str, str]) -> str:
+    """Serialize field format mappings to JSON."""
+
+    payload = {
+        key: value
+        for key, value in formats.items()
+        if key in FIELD_LIBRARY and isinstance(value, str)
+    }
+    return json.dumps(payload, separators=(",", ":"))

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -181,6 +181,43 @@ label.full {
   color: var(--color-muted);
 }
 
+.field-format-section {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.field-format-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field-format-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+}
+
+.field-format-item label {
+  gap: 0.4rem;
+}
+
+.field-format-item input {
+  width: 100%;
+}
+
+.field-format-reset {
+  padding: 0;
+  font-size: 0.85rem;
+  align-self: flex-start;
+}
+
 .checkbox {
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Summary
- render PDFs according to template layout_config blocks and apply field formatting strings
- store template field format mappings in the database and expose them via the API
- add template editor controls for customizing field formats and send them when saving templates

## Testing
- npm run build --prefix frontend
- python -m compileall backend/labelgen

------
https://chatgpt.com/codex/tasks/task_e_68dd4d79c0d88329ab8f34b74b2628fd