### PR TITLE
Add label layout selection and queue helpers

### DIFF
--- a/backend/labelgen/pdf.py
+++ b/backend/labelgen/pdf.py
@@ -697,9 +697,16 @@ def draw_label(
         )
 
 
+_PAGE_LAYOUTS: dict[int, tuple[int, int]] = {
+    10: (2, 5),
+    12: (2, 6),
+}
+
+
 def build_pdf(
     labels: Iterable[tuple[LabelData, int]],
     uploads_root: str | None = None,
+    labels_per_page: int = 12,
 ) -> bytes:
     """Generate a PDF containing the provided labels."""
 
@@ -707,8 +714,12 @@ def build_pdf(
     canv = canvas.Canvas(buffer, pagesize=letter)
     page_width, page_height = letter
     margin = 0.35 * inch
-    columns = 2
-    rows = 6
+
+    try:
+        columns, rows = _PAGE_LAYOUTS[int(labels_per_page)]
+    except (KeyError, TypeError, ValueError):
+        columns, rows = _PAGE_LAYOUTS[12]
+
     usable_width = page_width - 2 * margin
     usable_height = page_height - 2 * margin
     cell_width = usable_width / columns

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -463,6 +463,7 @@ function App() {
   const [imageFileLeft, setImageFileLeft] = useState(null);
   const [imageFileRight, setImageFileRight] = useState(null);
   const [printSelection, setPrintSelection] = useState({});
+  const [labelsPerPage, setLabelsPerPage] = useState(12);
   const [downloadingPdf, setDownloadingPdf] = useState(false);
   const [submittingLabel, setSubmittingLabel] = useState(false);
   const [submittingTemplate, setSubmittingTemplate] = useState(false);
@@ -925,6 +926,27 @@ function App() {
     });
   }
 
+  function selectAllLabels() {
+    if (!labels.length) {
+      return;
+    }
+    setPrintSelection((selection) => {
+      const next = {};
+      for (const label of labels) {
+        const current = selection[label.id];
+        next[label.id] = {
+          selected: true,
+          copies: current?.copies || label.default_copies || 1,
+        };
+      }
+      return next;
+    });
+  }
+
+  function clearLabelSelection() {
+    setPrintSelection({});
+  }
+
   function updateLabelCopies(labelId, value) {
     const numeric = Math.max(1, Number(value) || 1);
     setPrintSelection((selection) => {
@@ -953,6 +975,7 @@ function App() {
           label_id: label.id,
           copies,
         })),
+        labels_per_page: labelsPerPage,
       };
       const response = await fetch(`${API_BASE}/api/labels/print`, {
         method: 'POST',
@@ -1208,7 +1231,27 @@ function App() {
             </button>
           </form>
 
-          <h3>Labels</h3>
+          <div className="table-toolbar">
+            <h3>Labels</h3>
+            <div className="table-toolbar-actions">
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={selectAllLabels}
+                disabled={!labels.length}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={clearLabelSelection}
+                disabled={!selectedLabels.length}
+              >
+                Clear selection
+              </button>
+            </div>
+          </div>
           <div className="table">
             <div className="table-row table-head">
               <span>Select</span>
@@ -1440,6 +1483,13 @@ function App() {
             <span>{selectedLabels.length} labels selected</span>
           </div>
           <p>Select labels from the New label tab and adjust copies, then export a PDF.</p>
+          <div className="queue-layout-select">
+            <span>Labels per page</span>
+            <select value={labelsPerPage} onChange={(event) => setLabelsPerPage(Number(event.target.value))}>
+              <option value={12}>12 labels (2 × 6)</option>
+              <option value={10}>10 labels (2 × 5)</option>
+            </select>
+          </div>
           <div className="queue-list">
             {queueItems.length ? (
               queueItems.map(({ label, copies }) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -298,6 +298,38 @@ label.full {
   font-weight: 500;
 }
 
+.table-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.table-toolbar h3 {
+  margin: 0;
+}
+
+.table-toolbar-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.ghost-button {
+  border: 1px solid var(--color-border-strong);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-text);
+  padding: 0.45rem 0.85rem;
+  border-radius: 10px;
+  font-weight: 500;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.ghost-button:hover:not(:disabled) {
+  background: var(--color-surface-elevated);
+}
+
 .table {
   border: 1px solid var(--color-border);
   border-radius: 12px;
@@ -392,6 +424,22 @@ label.full {
   flex-direction: column;
   gap: 0.85rem;
   margin-bottom: 1rem;
+}
+
+.queue-layout-select {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.queue-layout-select span {
+  font-weight: 600;
+}
+
+.queue-layout-select select {
+  width: auto;
+  min-width: 180px;
 }
 
 .queue-row {


### PR DESCRIPTION
## Summary
- allow users to choose between 10-label or 12-label PDF layouts when exporting
- update the PDF generator and print API to honour the requested labels-per-page option
- add UI controls to select or clear all labels in the table for faster queue management

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7a1f68f8832984aaef19f3cdb7d0